### PR TITLE
Replace MDCTaskDecorator with spring-security agnostic and basic version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,7 @@
 version: 2
+
 updates:
+
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
@@ -15,6 +17,7 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,11 @@ updates:
         update-types:
           - "minor"
           - "patch"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    reviewers:
+      - "Jorich"
+      - "pr11t"
+      - "rammrain"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,9 +41,8 @@ jobs:
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
-        if: matrix.Java == '17'
         with:
-          name: report
+          name: report-java-${{ matrix.Java }}
           path: build/reports/**
           retention-days: 5
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,7 @@ jobs:
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
+        if: matrix.Java == '17'
         with:
           name: report
           path: build/reports/**

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ '17', '21' ]
+    name: Test with Java ${{ matrix.Java }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -19,10 +23,12 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: ${{ matrix.java }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: 8.6
 
       - name: Run tests and generate reports
         run: ./gradlew testAndReport

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
         run: ./gradlew testAndReport
 
       - name: Run Sonar analysis
+        id: matrix.Java == '17'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         run: ./gradlew testAndReport
 
       - name: Run Sonar analysis
-        id: matrix.Java == '17'
+        if: matrix.Java == '17'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -9,14 +9,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-version: 8.5
+          gradle-version: 8.6
       - name: Publish packages
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
 }
 
 group 'ee.bitweb'
-version '3.2.0'
+version '3.3.0'
 java {
     sourceCompatibility = '17'
 }

--- a/src/main/java/ee/bitweb/core/trace/thread/MDCTaskDecorator.java
+++ b/src/main/java/ee/bitweb/core/trace/thread/MDCTaskDecorator.java
@@ -1,37 +1,14 @@
 package ee.bitweb.core.trace.thread;
 
-import lombok.RequiredArgsConstructor;
-import org.slf4j.MDC;
-import org.springframework.core.task.TaskDecorator;
-import org.springframework.security.core.context.SecurityContextHolder;
-
-import java.util.Map;
+import ee.bitweb.core.trace.thread.decorator.SecurityAwareMDCTaskDecorator;
 
 /**
  * @deprecated use BasicMDCTaskDecorator or SecurityAwareMDCTaskDecorator
  */
 @Deprecated(since = "3.3.0", forRemoval = true)
-@RequiredArgsConstructor
-public class MDCTaskDecorator implements TaskDecorator {
+public class MDCTaskDecorator extends SecurityAwareMDCTaskDecorator {
 
-    private final ThreadTraceIdResolver resolver;
-
-    @Override
-    public Runnable decorate(Runnable runnable) {
-        Map<String, String> contextMap = MDC.getCopyOfContextMap();
-        var securityContext = SecurityContextHolder.getContext();
-
-        return () -> {
-            try {
-                MDC.setContextMap(contextMap);
-                SecurityContextHolder.setContext(securityContext);
-                resolver.resolve();
-
-                runnable.run();
-            } finally {
-                MDC.clear();
-                SecurityContextHolder.clearContext();
-            }
-        };
+    public MDCTaskDecorator(ThreadTraceIdResolver resolver) {
+        super(resolver);
     }
 }

--- a/src/main/java/ee/bitweb/core/trace/thread/decorator/BasicMDCTaskDecorator.java
+++ b/src/main/java/ee/bitweb/core/trace/thread/decorator/BasicMDCTaskDecorator.java
@@ -1,36 +1,29 @@
-package ee.bitweb.core.trace.thread;
+package ee.bitweb.core.trace.thread.decorator;
 
+import ee.bitweb.core.trace.thread.ThreadTraceIdResolver;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.MDC;
 import org.springframework.core.task.TaskDecorator;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.Map;
 
-/**
- * @deprecated use BasicMDCTaskDecorator or SecurityAwareMDCTaskDecorator
- */
-@Deprecated(since = "3.3.0", forRemoval = true)
 @RequiredArgsConstructor
-public class MDCTaskDecorator implements TaskDecorator {
+public class BasicMDCTaskDecorator implements TaskDecorator {
 
     private final ThreadTraceIdResolver resolver;
 
     @Override
     public Runnable decorate(Runnable runnable) {
         Map<String, String> contextMap = MDC.getCopyOfContextMap();
-        var securityContext = SecurityContextHolder.getContext();
 
         return () -> {
             try {
                 MDC.setContextMap(contextMap);
-                SecurityContextHolder.setContext(securityContext);
                 resolver.resolve();
 
                 runnable.run();
             } finally {
                 MDC.clear();
-                SecurityContextHolder.clearContext();
             }
         };
     }

--- a/src/main/java/ee/bitweb/core/trace/thread/decorator/BasicMDCTaskDecorator.java
+++ b/src/main/java/ee/bitweb/core/trace/thread/decorator/BasicMDCTaskDecorator.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.slf4j.MDC;
 import org.springframework.core.task.TaskDecorator;
 
+import java.util.HashMap;
 import java.util.Map;
 
 @RequiredArgsConstructor
@@ -14,11 +15,11 @@ public class BasicMDCTaskDecorator implements TaskDecorator {
 
     @Override
     public Runnable decorate(Runnable runnable) {
-        Map<String, String> contextMap = MDC.getCopyOfContextMap();
+        final Map<String, String> contextMap = MDC.getCopyOfContextMap();
 
         return () -> {
             try {
-                MDC.setContextMap(contextMap);
+                MDC.setContextMap(contextMap == null ? new HashMap<>() : contextMap);
                 resolver.resolve();
 
                 runnable.run();

--- a/src/main/java/ee/bitweb/core/trace/thread/decorator/SecurityAwareMDCTaskDecorator.java
+++ b/src/main/java/ee/bitweb/core/trace/thread/decorator/SecurityAwareMDCTaskDecorator.java
@@ -4,6 +4,7 @@ import ee.bitweb.core.trace.thread.ThreadTraceIdResolver;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.MDC;
 import org.springframework.core.task.TaskDecorator;
+import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.Map;
@@ -16,7 +17,7 @@ public class SecurityAwareMDCTaskDecorator implements TaskDecorator {
     @Override
     public Runnable decorate(Runnable runnable) {
         Map<String, String> contextMap = MDC.getCopyOfContextMap();
-        var securityContext = SecurityContextHolder.getContext();
+        SecurityContext securityContext = SecurityContextHolder.getContext();
 
         return () -> {
             try {

--- a/src/main/java/ee/bitweb/core/trace/thread/decorator/SecurityAwareMDCTaskDecorator.java
+++ b/src/main/java/ee/bitweb/core/trace/thread/decorator/SecurityAwareMDCTaskDecorator.java
@@ -1,5 +1,6 @@
-package ee.bitweb.core.trace.thread;
+package ee.bitweb.core.trace.thread.decorator;
 
+import ee.bitweb.core.trace.thread.ThreadTraceIdResolver;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.MDC;
 import org.springframework.core.task.TaskDecorator;
@@ -7,12 +8,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.Map;
 
-/**
- * @deprecated use BasicMDCTaskDecorator or SecurityAwareMDCTaskDecorator
- */
-@Deprecated(since = "3.3.0", forRemoval = true)
 @RequiredArgsConstructor
-public class MDCTaskDecorator implements TaskDecorator {
+public class SecurityAwareMDCTaskDecorator implements TaskDecorator {
 
     private final ThreadTraceIdResolver resolver;
 

--- a/src/main/java/ee/bitweb/core/trace/thread/decorator/SecurityAwareMDCTaskDecorator.java
+++ b/src/main/java/ee/bitweb/core/trace/thread/decorator/SecurityAwareMDCTaskDecorator.java
@@ -7,6 +7,7 @@ import org.springframework.core.task.TaskDecorator;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import java.util.HashMap;
 import java.util.Map;
 
 @RequiredArgsConstructor
@@ -16,13 +17,13 @@ public class SecurityAwareMDCTaskDecorator implements TaskDecorator {
 
     @Override
     public Runnable decorate(Runnable runnable) {
-        Map<String, String> contextMap = MDC.getCopyOfContextMap();
-        SecurityContext securityContext = SecurityContextHolder.getContext();
+        final Map<String, String> contextMap = MDC.getCopyOfContextMap();
+        final SecurityContext securityContext = SecurityContextHolder.getContext();
 
         return () -> {
             try {
-                MDC.setContextMap(contextMap);
-                SecurityContextHolder.setContext(securityContext);
+                MDC.setContextMap(contextMap == null ? new HashMap<>() : contextMap);
+                SecurityContextHolder.setContext(securityContext == null ? SecurityContextHolder.createEmptyContext() : securityContext);
                 resolver.resolve();
 
                 runnable.run();

--- a/src/test/java/ee/bitweb/core/trace/thread/decorator/BasicMDCTaskDecoratorTest.java
+++ b/src/test/java/ee/bitweb/core/trace/thread/decorator/BasicMDCTaskDecoratorTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockSettings;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.MDC;
@@ -46,6 +48,18 @@ class BasicMDCTaskDecoratorTest {
         } catch (RuntimeException ignored) {
             assertNull(MDC.get("custom-key"));
         }
+
+        Mockito.verifyNoMoreInteractions(resolver);
+    }
+
+    @Test
+    void testMDCIsPopulatedGivenMDCContextMapIsNull() {
+        Mockito.when(resolver.resolve()).thenReturn(null);
+        assertNull(MDC.getCopyOfContextMap());
+
+        new BasicMDCTaskDecorator(resolver).decorate(() -> {
+            assertNotNull(MDC.getCopyOfContextMap());
+        }).run();
 
         Mockito.verifyNoMoreInteractions(resolver);
     }

--- a/src/test/java/ee/bitweb/core/trace/thread/decorator/BasicMDCTaskDecoratorTest.java
+++ b/src/test/java/ee/bitweb/core/trace/thread/decorator/BasicMDCTaskDecoratorTest.java
@@ -1,0 +1,52 @@
+package ee.bitweb.core.trace.thread.decorator;
+
+import ee.bitweb.core.trace.thread.ThreadTraceIdResolver;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.MDC;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("unit")
+@ExtendWith(MockitoExtension.class)
+class BasicMDCTaskDecoratorTest {
+
+    @Mock
+    private ThreadTraceIdResolver resolver;
+
+    @Test
+    void testMDCIsPopulatedAndCleared() {
+        Mockito.when(resolver.resolve()).thenReturn(null);
+        MDC.put("custom-key", "custom-value");
+
+        new BasicMDCTaskDecorator(resolver).decorate(() -> {
+            assertEquals("custom-value", MDC.get("custom-key"));
+        }).run();
+
+        assertNull(MDC.get("custom-key"));
+
+        Mockito.verifyNoMoreInteractions(resolver);
+    }
+
+    @Test
+    void testMDCIsPopulatedAndClearedWhenExceptionIsThrown() {
+        Mockito.when(resolver.resolve()).thenReturn(null);
+        MDC.put("custom-key", "custom-value");
+
+        try {
+            new BasicMDCTaskDecorator(resolver).decorate(() -> {
+                assertEquals("custom-value", MDC.get("custom-key"));
+
+                throw new RuntimeException();
+            }).run();
+        } catch (RuntimeException ignored) {
+            assertNull(MDC.get("custom-key"));
+        }
+
+        Mockito.verifyNoMoreInteractions(resolver);
+    }
+}

--- a/src/test/java/ee/bitweb/core/trace/thread/decorator/SecurityAwareMDCTaskDecoratorTest.java
+++ b/src/test/java/ee/bitweb/core/trace/thread/decorator/SecurityAwareMDCTaskDecoratorTest.java
@@ -5,9 +5,12 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.MDC;
+import org.springframework.boot.actuate.endpoint.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -46,6 +49,37 @@ class SecurityAwareMDCTaskDecoratorTest {
         } catch (RuntimeException ignored) {
             assertNull(MDC.get("custom-key"));
         }
+
+        Mockito.verifyNoMoreInteractions(resolver);
+    }
+
+    @Test
+    void testMDCIsPopulatedGivenMDCContextMapIsNull() {
+        Mockito.when(resolver.resolve()).thenReturn(null);
+        assertNull(MDC.getCopyOfContextMap());
+
+        new SecurityAwareMDCTaskDecorator(resolver).decorate(() -> {
+            assertNotNull(MDC.getCopyOfContextMap());
+        }).run();
+
+        Mockito.verifyNoMoreInteractions(resolver);
+    }
+
+    @Test
+    void testDecorateCanHandleNullSecurityContext() {
+        Mockito.when(resolver.resolve()).thenReturn(null);
+
+        Runnable task;
+
+        try (MockedStatic<SecurityContextHolder> holder = Mockito.mockStatic(SecurityContextHolder.class)) {
+            holder.when(SecurityContextHolder::getContext).thenReturn(null);
+
+            task = new SecurityAwareMDCTaskDecorator(resolver).decorate(() -> {
+                assertNotNull(SecurityContextHolder.getContext());
+            });
+        }
+
+        task.run();
 
         Mockito.verifyNoMoreInteractions(resolver);
     }

--- a/src/test/java/ee/bitweb/core/trace/thread/decorator/SecurityAwareMDCTaskDecoratorTest.java
+++ b/src/test/java/ee/bitweb/core/trace/thread/decorator/SecurityAwareMDCTaskDecoratorTest.java
@@ -23,7 +23,7 @@ class SecurityAwareMDCTaskDecoratorTest {
         Mockito.when(resolver.resolve()).thenReturn(null);
         MDC.put("custom-key", "custom-value");
 
-        new BasicMDCTaskDecorator(resolver).decorate(() -> {
+        new SecurityAwareMDCTaskDecorator(resolver).decorate(() -> {
             assertEquals("custom-value", MDC.get("custom-key"));
         }).run();
 
@@ -38,7 +38,7 @@ class SecurityAwareMDCTaskDecoratorTest {
         MDC.put("custom-key", "custom-value");
 
         try {
-            new BasicMDCTaskDecorator(resolver).decorate(() -> {
+            new SecurityAwareMDCTaskDecorator(resolver).decorate(() -> {
                 assertEquals("custom-value", MDC.get("custom-key"));
 
                 throw new RuntimeException();

--- a/src/test/java/ee/bitweb/core/trace/thread/decorator/SecurityAwareMDCTaskDecoratorTest.java
+++ b/src/test/java/ee/bitweb/core/trace/thread/decorator/SecurityAwareMDCTaskDecoratorTest.java
@@ -1,0 +1,52 @@
+package ee.bitweb.core.trace.thread.decorator;
+
+import ee.bitweb.core.trace.thread.ThreadTraceIdResolver;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.MDC;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("unit")
+@ExtendWith(MockitoExtension.class)
+class SecurityAwareMDCTaskDecoratorTest {
+
+    @Mock
+    private ThreadTraceIdResolver resolver;
+
+    @Test
+    void testMDCIsPopulatedAndCleared() {
+        Mockito.when(resolver.resolve()).thenReturn(null);
+        MDC.put("custom-key", "custom-value");
+
+        new BasicMDCTaskDecorator(resolver).decorate(() -> {
+            assertEquals("custom-value", MDC.get("custom-key"));
+        }).run();
+
+        assertNull(MDC.get("custom-key"));
+
+        Mockito.verifyNoMoreInteractions(resolver);
+    }
+
+    @Test
+    void testMDCIsPopulatedAndClearedWhenExceptionIsThrown() {
+        Mockito.when(resolver.resolve()).thenReturn(null);
+        MDC.put("custom-key", "custom-value");
+
+        try {
+            new BasicMDCTaskDecorator(resolver).decorate(() -> {
+                assertEquals("custom-value", MDC.get("custom-key"));
+
+                throw new RuntimeException();
+            }).run();
+        } catch (RuntimeException ignored) {
+            assertNull(MDC.get("custom-key"));
+        }
+
+        Mockito.verifyNoMoreInteractions(resolver);
+    }
+}


### PR DESCRIPTION
Fix a bug where MDCTaskDecorator was depending on spring-security by adding new decorators for basic functionality and security agnostic functionality.

Other minor improvements:
* Added dependabot to GitHub Actions
* Run tests on Java 17 and 21