### PR TITLE
Add CI testing for Java 22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '17', '21' ]
+        java: [ '17', '21', '22' ]
     name: Test with Java ${{ matrix.Java }}
     steps:
       - name: Checkout code
@@ -27,8 +27,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-        with:
-          gradle-version: 8.6
 
       - name: Run tests and generate reports
         run: ./gradlew testAndReport

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,7 +1,9 @@
 name: Publish package to the Maven Central Repository
+
 on:
   release:
     types: [created]
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -15,8 +17,6 @@ jobs:
           java-version: 17
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-        with:
-          gradle-version: 8.6
       - name: Publish packages
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}


### PR DESCRIPTION
Run matrix tests for Java 22 to ensure compatibility. Sonar will run with Java 17. Build and release continue using Java 17.

Removed hard coded Gradle values to use latest Gradle version.