### PR TITLE
Replace Dependabot reviewers with codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @bitweb/tech

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    reviewers:
-      - "Jorich"
-      - "pr11t"
-      - "rammrain"
     groups:
       all-deps-minor-and-patch:
         patterns:
@@ -22,7 +18,3 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    reviewers:
-      - "Jorich"
-      - "pr11t"
-      - "rammrain"


### PR DESCRIPTION
Dependabot reviewers option has been deprecated, updating to codeowners.